### PR TITLE
feat!: improve color scheme preference handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@
 
 ## Features
 
-- Toggle between a light and dark color scheme
-- Considers system preference
-- Persist user preference
+* Toggle between light and dark color schemes
+* Respects the user's system color-scheme preference
+* Automatically follows system preference changes
+* Persists explicit user choices
+* Keyboard accessible with <kbd>Enter</kbd> and <kbd>Space</kbd>
+* No dependencies
 
 **[Demo](https://andreruffert.github.io/syntax-highlight-element)**
 
@@ -24,61 +27,113 @@ npm install color-scheme-switch-element
 
 ## Usage
 
-### JavaScript
+### Setup
 
 ```html
-<script>
-  // Ensure the event listener is setup before the initial `color-scheme-switch` event gets dispatched.
+<script type="module" async blocking="render">
+  import ColorSchemeSwitchElement from 'color-scheme-switch-element?define=false';
+
+  // Or via CDN
+  // import ColorSchemeSwitchElement from 'https://cdn.jsdelivr.net/npm/color-scheme-switch-element/+esm?define=false';
+
   document.addEventListener('color-scheme-switch', event => {
     const colorScheme = event.target.value;
-
-    // Set the page color scheme e.g
     document.documentElement.style.setProperty('color-scheme', colorScheme);
-    // ...
   });
+
+  // Define the element after the event listener has been registered so
+  // the initial color-scheme-switch event is not missed.
+  ColorSchemeSwitchElement.define();
 </script>
-<script type="module" async blocking="render" src="https://unpkg.com/color-scheme-switch-element@latest/dist/color-scheme-switch-element.js"></script>
 ```
-
-<!--
-Import as ES module:
-
-```js
-import ColorSchemeSwitchElement from 'color-scheme-switch-element?define=false'
-
-// Ensure the event listener is setup before the initial `color-scheme-switch` event gets dispatched.
-document.addEventListener('color-scheme-switch', event => {
-  const colorScheme = event.target.value;
-
-  // Set the page color scheme e.g
-  document.documentElement.style.setProperty('color-scheme', colorScheme);
-  // ...
-});
-
-ColorSchemeSwitchElement.define();
-```
--->
 
 ### Markup
 
 ```html
 <color-scheme-switch title="Toggle light & dark color scheme">
+  <!-- icon, label, etc. -->
+</color-scheme-switch>
+```
+
+The element supports `light` and `dark` color schemes.
+
+You can also provide an initial value declaratively:
+
+```html
+<color-scheme-switch value="dark">
   <!-- ... -->
 </color-scheme-switch>
 ```
 
+### Color scheme preference
+
+The initial value is determined in the following order:
+
+1. A valid persisted user preference from `localStorage`
+2. The `value` attribute
+3. The user's system preference (`prefers-color-scheme`)
+
+The persisted preference is stored under the `color-scheme` localStorage key.
+
+When the user toggles the element, their preference is persisted. If the selected scheme matches the current system preference, the persisted preference is removed so the component can continue following future system preference changes.
+
+If there is no persisted user preference, changes to the system color scheme are automatically reflected by the element.
+
+### Value
+
+The current color scheme is available through the `value` property:
+
+```js
+const colorScheme = element.value;
+
+element.value = 'dark';
+```
+
+Only `light` and `dark` are supported. Assigning any other value throws a `TypeError`.
+
+Changing `value` updates the component state and dispatches a `color-scheme-switch` event. Programmatically assigning `value` does **not** persist the preference; persistence only occurs when the user toggles the element.
+
 ### Events
 
-When initially loaded or after switching the color scheme, a `color-scheme-switch` event is dispatched from the `<color-scheme-switch>` element.
+A `color-scheme-switch` event is dispatched when the element is initialized and whenever its value changes.
 
 ```js
 document.addEventListener('color-scheme-switch', event => {
-  const button = event.target;
-  const colorScheme = event.target.value;
+  const element = event.target;
+  const colorScheme = element.value;
 
   // Set page color scheme, update aria-label, icon, etc.
-})
+});
 ```
+
+The event bubbles, so it can be listened for on `document` or another ancestor.
+
+Assigning the current value does not dispatch an event:
+
+```js
+element.value = element.value;
+```
+
+### Disabled
+
+The element can be disabled using the `disabled` attribute:
+
+```html
+<color-scheme-switch disabled>
+  <!-- ... -->
+</color-scheme-switch>
+```
+
+When disabled, user-triggered toggles are ignored.
+
+### Keyboard interaction
+
+When focused, the element responds to:
+
+* <kbd>Enter</kbd>
+* <kbd>Space</kbd>
+
+The element uses `role="button"` and `tabindex="0"` by default.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <title>&lt;color-scheme-switch&gt; element</title>
     <style>
       :root {
-        color-scheme: light-dark;
+        color-scheme: light dark;
       }
 
       body {
@@ -29,7 +29,7 @@
         gap: 0.5rem;
       }
     </style>
-    <script type="module" >
+    <script type="module" async blocking="render">
       import { ColorSchemeSwitchElement } from '/src/index.js?define=false'
 
       document.addEventListener('color-scheme-switch', event => {
@@ -50,8 +50,8 @@
     </script>
   </head>
   <body>
-    <color-scheme-switch value="dark" title="Toggle light & dark color scheme">
-      <svg class="icon" width="24" height="24"><use xlink:href="#sun"></use></svg>
+    <color-scheme-switch title="Toggle light & dark color scheme">
+      <svg class="icon" width="24" height="24"><use /></svg>
     </color-scheme-switch>
 
     <svg width="0" height="0" aria-hidden="true" hidden>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "2.1.2",
+        "@vitest/browser-playwright": "4.1.10",
         "conventional-changelog-cli": "5.0.0",
-        "vite": "8.1.0"
+        "vite": "8.1.0",
+        "vitest": "4.1.10"
       },
       "funding": {
         "url": "https://github.com/andreruffert/color-scheme-switch-element?sponsor=1"
@@ -205,6 +207,13 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@conventional-changelog/git-client": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-1.0.1.tgz",
@@ -275,6 +284,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -303,6 +319,13 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.3",
@@ -397,9 +420,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -417,9 +437,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -437,9 +454,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -457,9 +471,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -477,9 +488,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -497,9 +505,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -586,6 +591,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -596,6 +608,31 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -611,6 +648,166 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/browser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+      "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.10"
+      }
+    },
+    "node_modules/@vitest/browser-playwright": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.10.tgz",
+      "integrity": "sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/browser": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/add-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
@@ -624,6 +821,26 @@
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -854,6 +1071,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -875,6 +1099,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1290,6 +1541,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -1311,6 +1572,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/nanoid": {
@@ -1354,6 +1625,20 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/parse-json": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
@@ -1371,6 +1656,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1390,6 +1682,66 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {
@@ -1506,6 +1858,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1562,6 +1936,20 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/temp-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
@@ -1588,6 +1976,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -1603,6 +2008,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -1742,12 +2167,141 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,13 +23,16 @@
     "build": "vite build",
     "format": "biome check --write",
     "lint": "biome ci",
+    "test": "vitest",
     "prepublishOnly": "npm run build",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md"
   },
   "devDependencies": {
     "@biomejs/biome": "2.1.2",
+    "@vitest/browser-playwright": "4.1.10",
     "conventional-changelog-cli": "5.0.0",
-    "vite": "8.1.0"
+    "vite": "8.1.0",
+    "vitest": "4.1.10"
   },
   "volta": {
     "node": "22.13.1",

--- a/src/color-scheme-switch-element.js
+++ b/src/color-scheme-switch-element.js
@@ -1,42 +1,64 @@
 const DEFAULT_TAG_NAME = 'color-scheme-switch';
 const DEFAULT_STORAGE_KEY = 'color-scheme';
-const KEY_CODES = [' ', 'Enter'];
+const DARK_COLOR_SCHEME_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+const KEY_CODES = new Set([' ', 'Enter']);
+
+const isColorScheme = (value) => value === 'light' || value === 'dark';
 
 export class ColorSchemeSwitchElement extends HTMLElement {
+  /**
+   * Defines the custom element if it hasn't already been defined.
+   *
+   * @param {string} [tagName='color-scheme-switch']
+   * @param {CustomElementRegistry} [registry=customElements]
+   * @returns {typeof ColorSchemeSwitchElement}
+   */
   static define(tagName = DEFAULT_TAG_NAME, registry = customElements) {
     if (!registry.get(tagName)) {
       registry.define(tagName, ColorSchemeSwitchElement);
     }
+
     return ColorSchemeSwitchElement;
   }
 
   #value;
+  #systemPreference;
 
+  /**
+   * The currently active color scheme.
+   *
+   * @returns {'light'|'dark'}
+   */
   get value() {
     return this.#value;
   }
 
-  set value(newPreference) {
-    this.setAttribute('value', newPreference);
-    this.#value = newPreference;
-    localStorage.setItem(DEFAULT_STORAGE_KEY, newPreference);
+  /**
+   * Sets the currently active color scheme.
+   *
+   * @param {'light'|'dark'} value
+   * @throws {TypeError} If the value is not a supported color scheme.
+   */
+  set value(value) {
+    if (!isColorScheme(value)) {
+      throw new TypeError(`Invalid color scheme "${value}". Expected "light" or "dark".`);
+    }
+
+    if (this.#value === value) return;
+
+    this.#value = value;
     this.dispatchEvent(new CustomEvent('color-scheme-switch', { bubbles: true }));
   }
 
-  constructor() {
-    super();
-    this.addEventListener('click', this.toggle);
-    this.addEventListener('focus', this.#focusHandler);
-    this.addEventListener('blur', this.#blurHandler);
-  }
-
   connectedCallback() {
-    const systemColorScheme = this.getSystemColorScheme();
-    const pageColorScheme = this.getPageColorScheme();
-    const isSystem = pageColorScheme === 'light dark';
-    const defaultValue = isSystem ? systemColorScheme : pageColorScheme;
-    const persistedValue = localStorage.getItem(DEFAULT_STORAGE_KEY);
-    this.value = this.getAttribute('value') || persistedValue || defaultValue;
+    this.#systemPreference = window.matchMedia(DARK_COLOR_SCHEME_MEDIA_QUERY);
+    this.#systemPreference.addEventListener('change', this.#systemColorSchemeHandler);
+
+    this.addEventListener('click', this.toggle);
+    this.addEventListener('keydown', this.#keyboardHandler);
+
+    this.value = this.#getInitialValue();
 
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'button');
@@ -47,34 +69,86 @@ export class ColorSchemeSwitchElement extends HTMLElement {
     }
   }
 
-  #focusHandler = () => {
-    this.addEventListener('keydown', this.#keyboardHandler);
+  disconnectedCallback() {
+    this.removeEventListener('click', this.toggle);
+    this.removeEventListener('keydown', this.#keyboardHandler);
+
+    this.#systemPreference?.removeEventListener('change', this.#systemColorSchemeHandler);
+    this.#systemPreference = undefined;
+  }
+
+  /**
+   * Toggles between the light and dark color schemes.
+   */
+  toggle = () => {
+    if (this.hasAttribute('disabled')) return;
+
+    const value = this.#value === 'dark' ? 'light' : 'dark';
+    this.value = value;
+    this.#persistValue(value);
   };
 
-  #blurHandler = () => {
-    this.removeEventListener('keydown', this.#keyboardHandler);
-  };
+  /**
+   * Returns the user's current system color scheme preference.
+   *
+   * @returns {'light'|'dark'}
+   */
+  getSystemColorScheme() {
+    return this.#systemPreference.matches ? 'dark' : 'light';
+  }
+
+  /**
+   * Determines the initial color scheme.
+   *
+   * A persisted user preference takes precedence over the declarative
+   * `value` attribute, which falls back to the system preference.
+   *
+   * @returns {'light'|'dark'}
+   */
+  #getInitialValue() {
+    const persistedValue = localStorage.getItem(DEFAULT_STORAGE_KEY);
+
+    if (isColorScheme(persistedValue)) {
+      return persistedValue;
+    }
+
+    const defaultValue = this.getAttribute('value');
+
+    if (isColorScheme(defaultValue)) {
+      return defaultValue;
+    }
+
+    return this.getSystemColorScheme();
+  }
+
+  /**
+   * Persists a user-selected color scheme.
+   *
+   * Preferences matching the system scheme are removed so that
+   * future system changes continue to be followed automatically.
+   *
+   * @param {'light'|'dark'} value
+   */
+  #persistValue(value) {
+    if (value === this.getSystemColorScheme()) {
+      localStorage.removeItem(DEFAULT_STORAGE_KEY);
+    } else {
+      localStorage.setItem(DEFAULT_STORAGE_KEY, value);
+    }
+  }
 
   #keyboardHandler = (event) => {
-    if (!KEY_CODES.includes(event.key)) return;
+    if (!KEY_CODES.has(event.key)) return;
+
     event.preventDefault();
     this.toggle();
   };
 
-  getPageColorScheme() {
-    const computedStyle = window.getComputedStyle(document.documentElement);
-    const pageColorScheme = computedStyle.getPropertyValue('color-scheme');
-    return pageColorScheme;
-  }
+  #systemColorSchemeHandler = (event) => {
+    const persistedValue = localStorage.getItem(DEFAULT_STORAGE_KEY);
 
-  getSystemColorScheme() {
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  }
+    if (isColorScheme(persistedValue)) return;
 
-  toggle() {
-    if (this.disabled) return;
-    const currentPreference = this.#value;
-    const newPreference = currentPreference === 'dark' ? 'light' : 'dark';
-    this.value = newPreference;
-  }
+    this.value = event.matches ? 'dark' : 'light';
+  };
 }

--- a/test/color-scheme-switch-element.test.js
+++ b/test/color-scheme-switch-element.test.js
@@ -1,0 +1,531 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { ColorSchemeSwitchElement } from '../src/color-scheme-switch-element.js';
+
+const TAG_NAME = 'test-color-scheme-switch';
+const STORAGE_KEY = 'color-scheme';
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+
+function createMatchMediaController(initialMatches = false) {
+  let matches = initialMatches;
+  const listeners = new Set();
+
+  const mediaQueryList = {
+    get matches() {
+      return matches;
+    },
+
+    media: DARK_MEDIA_QUERY,
+
+    addEventListener(type, listener) {
+      if (type === 'change' && listener) {
+        listeners.add(listener);
+      }
+    },
+
+    removeEventListener(type, listener) {
+      if (type === 'change') {
+        listeners.delete(listener);
+      }
+    },
+
+    addListener() {},
+    removeListener() {},
+  };
+
+  return {
+    mediaQueryList,
+
+    setMatches(nextMatches) {
+      matches = nextMatches;
+
+      const event = {
+        matches: nextMatches,
+        media: DARK_MEDIA_QUERY,
+      };
+
+      for (const listener of [...listeners]) {
+        listener(event);
+      }
+    },
+  };
+}
+
+function createElement(attributes = {}) {
+  const element = document.createElement(TAG_NAME);
+
+  for (const [name, value] of Object.entries(attributes)) {
+    if (value !== undefined) {
+      element.setAttribute(name, value);
+    }
+  }
+
+  return element;
+}
+
+function mountElement(attributes = {}) {
+  const element = createElement(attributes);
+
+  document.body.append(element);
+
+  return element;
+}
+
+function setPersistedValue(value) {
+  localStorage.setItem(STORAGE_KEY, value);
+}
+
+let matchMediaController;
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  localStorage.clear();
+
+  matchMediaController = createMatchMediaController();
+
+  vi.spyOn(window, 'matchMedia').mockReturnValue(matchMediaController.mediaQueryList);
+
+  ColorSchemeSwitchElement.define(TAG_NAME);
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('ColorSchemeSwitchElement', () => {
+  describe('define()', () => {
+    test('defines the element in the provided registry', () => {
+      const registry = new CustomElementRegistry();
+      const tagName = 'another-color-scheme-switch';
+
+      const result = ColorSchemeSwitchElement.define(tagName, registry);
+
+      expect(result).toBe(ColorSchemeSwitchElement);
+      expect(registry.get(tagName)).toBe(ColorSchemeSwitchElement);
+    });
+  });
+
+  describe('value', () => {
+    test.each(['light', 'dark'])('accepts %s', (value) => {
+      const element = mountElement();
+
+      element.value = value;
+
+      expect(element.value).toBe(value);
+    });
+
+    test('rejects an invalid value', () => {
+      const element = mountElement();
+
+      element.value = 'light';
+
+      expect(() => {
+        element.value = 'system';
+      }).toThrow(new TypeError('Invalid color scheme "system". Expected "light" or "dark".'));
+
+      expect(element.value).toBe('light');
+    });
+
+    test('does not dispatch when the value does not change', () => {
+      const element = mountElement({ value: 'light' });
+      const handler = vi.fn();
+
+      element.addEventListener('color-scheme-switch', handler);
+
+      element.value = 'dark';
+      element.value = 'dark';
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    test('dispatches a bubbling CustomEvent when the value changes', () => {
+      const parent = document.createElement('div');
+      const element = createElement();
+
+      parent.append(element);
+      document.body.append(parent);
+
+      const handler = vi.fn();
+
+      parent.addEventListener('color-scheme-switch', handler);
+
+      element.value = 'dark';
+
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      const [event] = handler.mock.calls[0];
+
+      expect(event).toBeInstanceOf(CustomEvent);
+      expect(event.bubbles).toBe(true);
+      expect(event.target).toBe(element);
+    });
+  });
+
+  describe('initial value', () => {
+    test('follows the light system preference by default', () => {
+      matchMediaController.setMatches(false);
+
+      const element = mountElement();
+
+      expect(element.value).toBe('light');
+    });
+
+    test('follows the dark system preference by default', () => {
+      matchMediaController.setMatches(true);
+
+      const element = mountElement();
+
+      expect(element.value).toBe('dark');
+    });
+
+    test('prefers persisted value over the system preference', () => {
+      setPersistedValue('light');
+      matchMediaController.setMatches(true);
+
+      const element = mountElement();
+
+      expect(element.value).toBe('light');
+    });
+
+    test('prefers persisted value over the value attribute', () => {
+      setPersistedValue('dark');
+
+      const element = mountElement({
+        value: 'light',
+      });
+
+      expect(element.value).toBe('dark');
+    });
+
+    test('uses the value attribute when no valid persisted value exists', () => {
+      const element = mountElement({
+        value: 'dark',
+      });
+
+      expect(element.value).toBe('dark');
+    });
+
+    test('falls back to the system preference for an invalid value attribute', () => {
+      matchMediaController.setMatches(true);
+
+      const element = mountElement({
+        value: 'invalid',
+      });
+
+      expect(element.value).toBe('dark');
+    });
+
+    test('falls back to the system preference for an invalid persisted value', () => {
+      setPersistedValue('invalid');
+      matchMediaController.setMatches(true);
+
+      const element = mountElement();
+
+      expect(element.value).toBe('dark');
+    });
+  });
+
+  describe('accessibility', () => {
+    test('defaults role to button', () => {
+      const element = mountElement();
+
+      expect(element).toHaveAttribute('role', 'button');
+    });
+
+    test('preserves an explicit role', () => {
+      const element = mountElement({
+        role: 'switch',
+      });
+
+      expect(element).toHaveAttribute('role', 'switch');
+    });
+
+    test('defaults tabindex to 0', () => {
+      const element = mountElement();
+
+      expect(element).toHaveAttribute('tabindex', '0');
+    });
+
+    test('preserves an explicit tabindex', () => {
+      const element = mountElement({
+        tabindex: '-1',
+      });
+
+      expect(element).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  describe('getSystemColorScheme()', () => {
+    test.each([
+      [false, 'light'],
+      [true, 'dark'],
+    ])('returns %s for a %s system preference', (matches, expected) => {
+      matchMediaController.setMatches(matches);
+
+      const element = mountElement();
+
+      expect(element.getSystemColorScheme()).toBe(expected);
+    });
+  });
+
+  describe('toggle()', () => {
+    test.each([
+      ['light', 'dark'],
+      ['dark', 'light'],
+    ])('toggles %s to %s', (current, expected) => {
+      const element = mountElement({
+        value: current,
+      });
+
+      element.toggle();
+
+      expect(element.value).toBe(expected);
+    });
+
+    test('persists a value different from the system preference', () => {
+      matchMediaController.setMatches(false);
+
+      const element = mountElement({
+        value: 'light',
+      });
+
+      element.toggle();
+
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('dark');
+    });
+
+    test('removes persistence when the selected value matches the system preference', () => {
+      matchMediaController.setMatches(false);
+      setPersistedValue('dark');
+
+      const element = mountElement();
+
+      element.toggle();
+
+      expect(element.value).toBe('light');
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    test('dispatches a change event', () => {
+      const element = mountElement({
+        value: 'light',
+      });
+      const handler = vi.fn();
+
+      element.addEventListener('color-scheme-switch', handler);
+
+      element.toggle();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    test('does nothing when disabled', () => {
+      const element = mountElement({
+        value: 'light',
+        disabled: '',
+      });
+      const handler = vi.fn();
+
+      element.addEventListener('color-scheme-switch', handler);
+
+      element.toggle();
+
+      expect(element.value).toBe('light');
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('click', () => {
+    test('toggles the value', () => {
+      const element = mountElement({
+        value: 'light',
+      });
+
+      element.click();
+
+      expect(element.value).toBe('dark');
+    });
+
+    test('does not toggle when disabled', () => {
+      const element = mountElement({
+        value: 'light',
+        disabled: '',
+      });
+
+      element.click();
+
+      expect(element.value).toBe('light');
+    });
+  });
+
+  describe('keyboard', () => {
+    test.each([
+      ['Enter', 'Enter'],
+      ['Space', ' '],
+    ])('toggles on %s and prevents the default action', (_name, key) => {
+      const element = mountElement({
+        value: 'light',
+      });
+
+      const event = new KeyboardEvent('keydown', {
+        key,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      element.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(element.value).toBe('dark');
+    });
+
+    test('ignores unrelated keys', () => {
+      const element = mountElement({
+        value: 'light',
+      });
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        bubbles: true,
+        cancelable: true,
+      });
+
+      element.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(element.value).toBe('light');
+    });
+
+    test('does not toggle when disabled', () => {
+      const element = mountElement({
+        value: 'light',
+        disabled: '',
+      });
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      });
+
+      element.dispatchEvent(event);
+
+      expect(element.value).toBe('light');
+      expect(event.defaultPrevented).toBe(true);
+    });
+  });
+
+  describe('system preference changes', () => {
+    test('updates when the system preference changes without a persisted preference', () => {
+      matchMediaController.setMatches(false);
+
+      const element = mountElement();
+
+      expect(element.value).toBe('light');
+
+      matchMediaController.setMatches(true);
+
+      expect(element.value).toBe('dark');
+    });
+
+    test('updates in both directions', () => {
+      matchMediaController.setMatches(true);
+
+      const element = mountElement();
+
+      expect(element.value).toBe('dark');
+
+      matchMediaController.setMatches(false);
+
+      expect(element.value).toBe('light');
+    });
+
+    test('ignores system changes when a valid preference is persisted', () => {
+      setPersistedValue('light');
+      matchMediaController.setMatches(false);
+
+      const element = mountElement();
+
+      matchMediaController.setMatches(true);
+
+      expect(element.value).toBe('light');
+    });
+
+    test('continues following the system when persisted value is invalid', () => {
+      setPersistedValue('invalid');
+      matchMediaController.setMatches(false);
+
+      const element = mountElement();
+
+      expect(element.value).toBe('light');
+
+      matchMediaController.setMatches(true);
+
+      expect(element.value).toBe('dark');
+    });
+  });
+
+  describe('lifecycle', () => {
+    test('removes interaction listeners when disconnected', () => {
+      const element = mountElement({
+        value: 'light',
+      });
+
+      element.remove();
+
+      element.click();
+
+      element.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+        }),
+      );
+
+      expect(element.value).toBe('light');
+    });
+
+    test('removes the system preference listener when disconnected', () => {
+      const removeEventListener = vi.spyOn(
+        matchMediaController.mediaQueryList,
+        'removeEventListener',
+      );
+
+      const element = mountElement();
+
+      element.remove();
+
+      expect(removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+    });
+
+    test('stops following system changes while disconnected', () => {
+      const element = mountElement({
+        value: 'light',
+      });
+
+      element.remove();
+
+      matchMediaController.setMatches(true);
+
+      expect(element.value).toBe('light');
+    });
+
+    test('resumes following system changes after reconnecting', () => {
+      matchMediaController.setMatches(false);
+
+      const element = mountElement();
+
+      element.remove();
+
+      matchMediaController.setMatches(true);
+
+      expect(element.value).toBe('light');
+
+      document.body.append(element);
+
+      expect(element.value).toBe('dark');
+    });
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vite';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -11,6 +12,18 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.js'),
       name: 'ColorSchemeSwitch',
       fileName: 'color-scheme-switch-element',
+    },
+  },
+  test: {
+    browser: {
+      enabled: true,
+      headless: true,
+      provider: playwright(),
+      instances: [
+        {
+          browser: 'chromium',
+        },
+      ],
     },
   },
 });


### PR DESCRIPTION
## What changed (additional context)

* validate color scheme values and reject unsupported values
* separate component state from localStorage persistence
* persist only explicit user toggles
* remove persisted preferences that match the system scheme
* automatically follow system color-scheme changes when no user preference exists
* change initialization precedence to persisted preference, then `value` attribute, then system preference
* clean up event listeners when the element disconnects
* simplify keyboard handling with a Set of supported keys
* add JSDoc and avoid redundant value updates
* introduce tests

BREAKING CHANGE:

* Setting `element.value` no longer persists the value to localStorage
* Setting `element.value` to anything other than `light` or `dark` now throws a TypeError
* A persisted color-scheme preference now takes precedence over the declarative `value` attribute